### PR TITLE
Add paging support for list resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "ecs-nav"
-version = "0.1.0"
+version = "0.0.2"
 dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "ecs-nav"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecs-nav"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This pull request includes a significant change to the `list_services` function in the `src/ecs.rs` file. The update involves switching from a single request to using a paginator for listing services, which allows for handling multiple pages of results.

Improvements to service listing:

* [`src/ecs.rs`](diffhunk://#diff-75f9f0489447c8e2c0b997f7ae79df74a31029ad1306315af83ae2ef47d33f5cL117-R133): Modified the `list_services` function to use a paginator, improving the handling of multiple pages of service ARNs. This change involves collecting service ARNs from each page and extending the `services` vector accordingly.