### PR TITLE
Use `execvp` for Command Execution in ECS-Exec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "ecs-nav"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +537,7 @@ dependencies = [
  "aws-sdk-dynamodb",
  "aws-sdk-ecs",
  "dialoguer",
+ "nix",
  "tokio",
 ]
 
@@ -887,6 +894,18 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ aws-config = { version= "1.5.0", features = ["behavior-version-latest"] }
 aws-sdk-dynamodb = "1.30.1"
 aws-sdk-ecs = "1.28.0"
 dialoguer = "0.11.0"
+nix = {version = "0.29.0", features = ["process"]}
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecs-nav"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION

### **Description**

This pull request replaces the child process spawning (`Command::new`) approach with `execvp` to improve handling of control sequences (e.g., `Ctrl+C`) during interactive ECS-Exec sessions.

#### **Key Changes**
- Replaced `Command::new` with `execvp` for directly executing the `aws ecs execute-command`.
- Added proper argument handling using `CString` to ensure compatibility with `execvp`.
- Improved error handling and code readability.

